### PR TITLE
Fix for psh switch type conversion error and WebClient download

### DIFF
--- a/Public/Get-DownOSDBuilder.ps1
+++ b/Public/Get-DownOSDBuilder.ps1
@@ -187,6 +187,9 @@ function Get-DownOSDBuilder {
             #   Download Updates
             #===================================================================================================
             if ($Download.IsPresent) {
+				if ($WebClient.IsPresent) {							
+				$WebClientObj = New-Object System.Net.WebClient
+				}
                 foreach ($Update in $OSDUpdates) {
                     $DownloadPath = "$OSDBuilderPath\Content\OSDUpdate\$($Update.Catalog)\$($Update.Title)"
                     $DownloadFullPath = "$DownloadPath\$($Update.FileName)"
@@ -195,9 +198,8 @@ function Get-DownOSDBuilder {
                     if (!(Test-Path $DownloadFullPath)) {
                         Write-Host "$DownloadFullPath" -ForegroundColor Cyan
                         Write-Host "$($Update.OriginUri)" -ForegroundColor DarkGray
-                        if ($WebClient.IsPresent) {
-                            $WebClient = New-Object System.Net.WebClient
-                            $WebClient.DownloadFile("$($Update.OriginUri)","$DownloadFullPath")
+                        if ($WebClient.IsPresent) {							
+                            $WebClientObj.DownloadFile("$($Update.OriginUri)","$DownloadFullPath")
                         } else {
                             Start-BitsTransfer -Source $Update.OriginUri -Destination $DownloadFullPath
                         }

--- a/Public/Get-DownOSDBuilder.ps1
+++ b/Public/Get-DownOSDBuilder.ps1
@@ -187,9 +187,7 @@ function Get-DownOSDBuilder {
             #   Download Updates
             #===================================================================================================
             if ($Download.IsPresent) {
-				if ($WebClient.IsPresent) {							
-				$WebClientObj = New-Object System.Net.WebClient
-				}
+				if ($WebClient.IsPresent) {$WebClientObj = New-Object System.Net.WebClient}
                 foreach ($Update in $OSDUpdates) {
                     $DownloadPath = "$OSDBuilderPath\Content\OSDUpdate\$($Update.Catalog)\$($Update.Title)"
                     $DownloadFullPath = "$DownloadPath\$($Update.FileName)"


### PR DESCRIPTION
Received "Cannot convert the 'System.Net.WebClient' value of type 'System.Net.WebClient' to type 'System.Management.Automation.SwitchParameter'" when using the WebClient parameter.
Changed the object for the WebClient to be different to the switch variable name and moved the object creation outside the download loop so not to unnecessarily recreate the object.